### PR TITLE
Prevent counting a boolean when result is empty

### DIFF
--- a/classes/object_manipulator/puller.php
+++ b/classes/object_manipulator/puller.php
@@ -70,7 +70,12 @@ class puller extends manipulator {
         $objects = get_records_sql_array($sql, $params);
         $this->logger->end_timing();
 
-        $totalobjectsfound = count($objects);
+        // If there are no results, false is returned.
+        if ($objects === false) {
+            $totalobjectsfound = 0;
+        } else {
+            $totalobjectsfound = count($objects);
+        }
 
         $this->logger->log_object_query('get_pull_candidates', $totalobjectsfound);
 


### PR DESCRIPTION
```
[WAR] 5f (module/objectfs/classes/object_manipulator/puller.php:73) count(): Parameter must be an array or an object that implements Countable
Call stack (most recent first):
* log_message("count(): Parameter must be an array or an object t...", 8, true, true, "/var/www/site/module/objectfs/classes/object_manip...", 73) at /var/www/site/lib/errors.php:515
* error(2, "count(): Parameter must be an array or an object t...", "/var/www/site/module/objectfs/classes/object_manip...", 73, array(size 3)) at Unknown:0
* count(false) at /var/www/site/module/objectfs/classes/object_manipulator/puller.php:73
* module_objectfs\object_manipulator\puller->get_candidate_objects() at /var/www/site/module/objectfs/classes/object_manipulator/manipulator.php:167
* module_objectfs\object_manipulator\manipulator::setup_and_run_object_manipulator("puller") at /var/www/site/module/objectfs/lib.php:323
* PluginModuleObjectfs::pull_objects_from_storage() at Unknown:0
* call_user_func_array(array(size 2), array(size 0)) at /var/www/site/lib/mahara.php:1896
* call_static_method("PluginModuleObjectfs", "pull_objects_from_storage") at /var/www/site/lib/cron.php:122
```

When the query has no records a boolean value is returned. When you count a boolean above warning message rises.