### PR TITLE
fix Aws\Exception\InvalidRegionException: Region must be a valid RFC …

### DIFF
--- a/objectfslib.php
+++ b/objectfslib.php
@@ -80,7 +80,7 @@ function get_objectfs_config() {
     $config->s3_key = '';
     $config->s3_secret = '';
     $config->s3_bucket = '';
-    $config->s3_region = '';
+    $config->s3_region = 'us-east-1';
 
     $config->azure_accountname = '';
     $config->azure_container = '';


### PR DESCRIPTION
By updating sdk to 3.212.6 (https://github.com/catalyst/mahara-module_aws/tree/update_to_3.212.6/sdk), phpunit will check for S3_region that is missing. This is fixed by adding the a value to $config->s3_region (using the same value as https://github.com/catalyst/mahara-module_objectfs/blob/master/objectfslib.php#L71)

```
PHPUnit 8.5.24 #StandWithUkraine

..E............................................................  63 / 224 ( 28%)
............................................................... 126 / 224 ( 56%)
............................................................... 189 / 224 ( 84%)
................................SSS                             224 / 224 (100%)

Time: 1.33 minutes, Memory: 42.50 MB

There was 1 error:

1) ArtefactTest::testArtefactHierarchyMove
Aws\Exception\InvalidRegionException: Region must be a valid RFC host label.

/var/www/client/htdocs/module/aws/sdk/Aws/ClientResolver.php:610
/var/www/client/htdocs/module/aws/sdk/Aws/ClientResolver.php:352
/var/www/client/htdocs/module/aws/sdk/Aws/AwsClient.php:199
/var/www/client/htdocs/module/aws/sdk/Aws/S3/S3Client.php:355
/var/www/client/htdocs/module/aws/sdk/Aws/AwsClient.php:447
/var/www/client/htdocs/module/objectfs/classes/client/s3_client.php:85
/var/www/client/htdocs/module/objectfs/classes/client/s3_client.php:57
/var/www/client/htdocs/module/objectfs/classes/s3_file_system.php:28
/var/www/client/htdocs/module/objectfs/classes/object_file_system.php:37
/var/www/client/htdocs/artefact/file/lib.php:491
/var/www/client/htdocs/artefact/file/lib.php:1087
/var/www/client/htdocs/lib/tests/phpunit/ArtefactTest.php:104
phpvfscomposer:///var/www/client/external/vendor/phpunit/phpunit/phpunit:97

ERRORS!
Tests: 224, Assertions: 457, Errors: 1, Skipped: 3.
```