### PR TITLE
Improve file transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ S3 specific settings
 - **Bucket**: S3 bucket name to store files in
 - **AWS region**: AWS API endpoint region to use.
 
+## Release 2.0.0 impact
+
+A major change in this release impacts all files stored in the module_objectfs_objects table. The ID stored in this table have changed from referencing the fileid to referencing the artefactid.
+
+If you have moved files to S3 and have not deleted local files, it is recommended to delete all records in the module_objectfs_objects and initiate the upload again.
+
+If you have moved files to S3 and have deleted local files, a script will need to be written to update the IDs from fileid to artefactid based on the file hash. This script has not been written in this release. We welcome merge requests to implement this change.
+
 ## Backporting
 
 If you are on an older mahara then you can backport the necessary API's in order to support this plugin. Use with caution!

--- a/classes/object_file_system.php
+++ b/classes/object_file_system.php
@@ -71,7 +71,7 @@ abstract class object_file_system {
 
         $file = get_record('artefact_file_files', 'contenthash', $contenthash);
         $fileartefact = new \ArtefactTypeFile($file->fileid);
-        $path = $fileartefact->get_local_path();
+        $path = $fileartefact->get_local_path(array(), false);
 
         if ($fetchifnotfound && !is_readable($path)) {
 
@@ -208,7 +208,7 @@ abstract class object_file_system {
 
         if ($initiallocation === OBJECT_LOCATION_LOCAL) {
 
-            $localpath = $fileartefact->get_local_path();
+            $localpath = $fileartefact->get_local_path(array(), false);
             $externalpath = $this->get_external_path_from_hash($contenthash);
 
             $success = copy($localpath, $externalpath);
@@ -228,7 +228,7 @@ abstract class object_file_system {
 
     public function verify_external_object($fileartefact) {
         $contenthash = $fileartefact->get('contenthash');
-        $localpath = $fileartefact->get_local_path();
+        $localpath = $fileartefact->get_local_path(array(), false);
         $objectisvalid = $this->externalclient->verify_object($contenthash, $localpath);
         return $objectisvalid;
     }
@@ -239,7 +239,7 @@ abstract class object_file_system {
         $finallocation = $initiallocation;
 
         if ($initiallocation === OBJECT_LOCATION_DUPLICATED) {
-            $localpath = $fileartefact->get_local_path();
+            $localpath = $fileartefact->get_local_path(array(), false);
 
             if ($this->verify_external_object($fileartefact)) {
                 $success = unlink($localpath);

--- a/classes/object_file_system.php
+++ b/classes/object_file_system.php
@@ -102,7 +102,7 @@ abstract class object_file_system {
         }
 
         if ($this->is_file_readable_locally($fileartefact)) {
-            return $fileartefact->get_local_path();
+            return $fileartefact->get_local_path(array(), false);
         }
 
         if ($contenthash) {
@@ -172,8 +172,7 @@ abstract class object_file_system {
         $finallocation = $initiallocation;
 
         if ($initiallocation === OBJECT_LOCATION_EXTERNAL) {
-
-            $localpath = $fileartefact->get_local_path();
+            $localpath = $fileartefact->get_local_path(array(), false);
             $externalpath = $this->get_external_path_from_hash($contenthash);
 
             $localdirpath = get_config('dataroot')."/".$fileartefact::get_file_directory($fileartefact->get('fileid'));

--- a/classes/object_file_system.php
+++ b/classes/object_file_system.php
@@ -175,8 +175,13 @@ abstract class object_file_system {
             $localpath = $fileartefact->get_local_path(array(), false);
             $externalpath = $this->get_external_path_from_hash($contenthash);
 
-            $localdirpath = get_config('dataroot')."/".$fileartefact::get_file_directory($fileartefact->get('fileid'));
-
+            $artefacttype = $fileartefact->get('artefacttype');
+            if ($artefacttype === "profileicon") {
+                $localdirpath = get_config('dataroot')."/".$fileartefact::get_profileicon_file_directory($fileartefact->get('fileid'));
+            }
+            else {
+                $localdirpath = get_config('dataroot') . "/" . $fileartefact::get_file_directory($fileartefact->get('fileid'));
+            }
             // Folder may not exist yet if pulling a file that came from another environment.
             if (!is_dir($localdirpath)) {
                 if (!mkdir($localdirpath, $this->dirpermissions, true)) {

--- a/classes/object_manipulator/deleter.php
+++ b/classes/object_manipulator/deleter.php
@@ -93,7 +93,12 @@ class deleter extends manipulator {
         $objects = get_records_sql_array($sql, $params);
         $this->logger->end_timing();
 
-        $totalobjectsfound = count($objects);
+        // If there are no results, false is returned.
+        if ($objects === false) {
+            $totalobjectsfound = 0;
+        } else {
+            $totalobjectsfound = count($objects);
+        }
 
         $this->logger->log_object_query('get_delete_candidates', $totalobjectsfound);
 

--- a/classes/object_manipulator/manipulator.php
+++ b/classes/object_manipulator/manipulator.php
@@ -47,7 +47,7 @@ abstract class manipulator {
      *
      * @var array
      */
-    protected $supportedartefacttypes = array('file', 'archive', 'video', 'audio', 'image');
+    protected $supportedartefacttypes = array('file', 'archive', 'video', 'audio', 'image', 'profileicon');
 
     /**
      * Manipulator constructor

--- a/classes/object_manipulator/pusher.php
+++ b/classes/object_manipulator/pusher.php
@@ -87,8 +87,12 @@ class pusher extends manipulator {
         $objects = get_records_sql_array($sql, $params);
         $this->logger->end_timing();
 
-        $totalobjectsfound = count($objects);
-
+        // If there are no results, false is returned.
+        if ($objects === false) {
+            $totalobjectsfound = 0;
+        } else {
+            $totalobjectsfound = count($objects);
+        }
         $this->logger->log_object_query('get_push_candidates', $totalobjectsfound);
 
         return $objects;

--- a/classes/object_manipulator/recoverer.php
+++ b/classes/object_manipulator/recoverer.php
@@ -60,7 +60,12 @@ class recoverer extends manipulator {
         $objects = get_records_sql_array($sql, $params);
         $this->logger->end_timing();
 
-        $totalobjectsfound = count($objects);
+        // If there are no results, false is returned.
+        if ($objects === false) {
+            $totalobjectsfound = 0;
+        } else {
+            $totalobjectsfound = count($objects);
+        }
 
         $this->logger->log_object_query('get_recover_candidates', $totalobjectsfound);
         return $objects;

--- a/objectfslib.php
+++ b/objectfslib.php
@@ -23,14 +23,14 @@ function update_object_record($fileartefact, $location) {
 
     $newobject = new \stdClass();
     $newobject->contenthash = $fileartefact->get('contenthash');
-    $newobject->contentid = $fileartefact->get('fileid');
+    $newobject->contentid = $fileartefact->get('id');
     $newobject->timeduplicated = time();
     $newobject->location = $location;
 
     $oldobject = get_record(
         'module_objectfs_objects',
         'contenthash', $fileartefact->get('contenthash'),
-        'contentid', $fileartefact->get('fileid')
+        'contentid', $fileartefact->get('id')
     );
 
     if ($oldobject) {

--- a/objectfslib.php
+++ b/objectfslib.php
@@ -80,7 +80,7 @@ function get_objectfs_config() {
     $config->s3_key = '';
     $config->s3_secret = '';
     $config->s3_bucket = '';
-    $config->s3_region = '';
+    $config->s3_region = 'us-east-1';
 
     $config->azure_accountname = '';
     $config->azure_container = '';

--- a/version.php
+++ b/version.php
@@ -11,8 +11,8 @@
 defined('INTERNAL') || die();
 
 $config = new stdClass();
-$config->version   = 2018012901;      // The current plugin version (Date: YYYYMMDDXX).
-$config->release   = '1.0.0';
+$config->version   = 2022050300;      // The current plugin version (Date: YYYYMMDDXX).
+$config->release   = '2.0.0';
 
 $config->dependencies = array(
     'module_aws' => 2017030100


### PR DESCRIPTION
Adding a few things:
- instead of checking fileid, this will now check artefact id as contentid. This is because artefacts can have the same fileid, so when it checked that fileid is the same, it skipped the artefact. https://github.com/catalyst/mahara-module_objectfs/blob/improve_file_transfers/objectfslib.php#L36-L46, the change would ensure it would be added/inserted to module_objectfs_objectfs
- setting $generateifpossible = false to avoid recursion/infinite loop (see related: https://bugs.launchpad.net/mahara/+bug/1776364)
- adding profileicon in a list of supported file