### PR TITLE
Update README.md with branch info

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Some of our clients maharas are truly massive. We also have multiple environment
 
 Using this plugin we can configure production to have full read write to the remote filesystem and store the vast bulk of content remotely. In this setup the latency and bandwidth isn't an issue as they are colocated. The local filedir on disk would only consist of small or fast churning files. A refresh of the production data back to a staging environment can be much quicker now as we skip the sitedir clone completely and stage is simple configured with readonly access to the production filesystem. Any files it creates would only be written to it's local filesystem which can then be discarded when next refreshed.
 
+## Supported Mahara Versions
+
+| Mahara version       | Branch              |
+|----------------------|---------------------|
+| Mahara 25.04+        | MAHARA_2504_STABLE  |
+| Mahara 18.04 - 24.04 | master              |
+
 ## Installation
 1. If not on Mahara 18.04, backport the file system API. See [Backporting](#backporting)
 2. Setup your remote object storage. See [Remote object storage setup](#amazon-s3)


### PR DESCRIPTION
As we now have a dedicated branch for Mahara 25.04 it's worth adding branch info to the readme file.

I was a bit struggling identifying Mahara version the main branch started with. Based on the Installation notes https://github.com/catalyst/mahara-module_objectfs?tab=readme-ov-file#installation that point out to Mahara 18.04 I guess we can put 18.04 as the minimum version assuming the older versions would require some additional backporting. In any case, 18.04 is quite old, and we don’t need to worry about making this README super accurate for even older versions.